### PR TITLE
Adding missing parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,6 +146,7 @@ module.exports = class SocketCusterEngine {
             key,
             this.constructor.scMethodsWithoutCapture[key],
             template(requestSpec[key], context),
+            context,
             callback
           );
         };


### PR DESCRIPTION
When testing sending `transmitPublish` it was failing because of this missing param.